### PR TITLE
#159993334 Add Test Coverage From Code Climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,14 @@ cache:
     - node_modules
 before_script:
   - npm install codeclimate-test-reporter -g
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - npm test
   - npm test -- --coverage
   - npm run build
 after_script:
-  - codeclimate-test-reporter < ./coverage/lcov.info
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 # notifications:
 #     slack: andela:ODqDIMkl1Ds56Jxyrwc825vT

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - npm install codeclimate-test-reporter istanbul -g
 script:
   - npm test
-  - istanbul cover npm test -- -R spec
+  - istanbul cover npm test
   - npm run build
 after_script:
   - codeclimate-test-reporter < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
   directories:
     - node_modules
 before_script:
-  - npm install codeclimate-test-reporter -g
+  - npm install codeclimate-test-reporter istanbul -g
 script:
   - npm test
-  - npm test -- --coverage
+  - istanbul cover
   - npm run build
 after_script:
   - codeclimate-test-reporter < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ script:
   - npm run build
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-# notifications:
-#     slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
+notifications:
+    slack: andela:ODqDIMkl1Ds56Jxyrwc825vT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,21 @@
 # travis configurations
-env:
-  global:
-    - CC_TEST_REPORTER_ID=ac09bc8945acb8a19e553ee46e5ddeab8058ac70cc6cd85cfb2dabb06331e11b
 language: node_js
 node_js:
   - "stable"
-cache:
-  directories:
-    - node_modules
 addons:
   code_climate:
     repo_token:
       secure: "m+NV4GPL9cEIHjnajmlvHqD9bLlWLng60i/t+Ih7CQrYvbWmf1/PHaDERayRJPP9i5vxc1NhI23IRwJybnrZGiH1oqiVx77JVBcVPl2WbNntVWsPWlsIj34uLWI+nDS85NBj3JHpLCT43Go3ECYkYSLU8sRNf+8IYVlc8g5zVKsZtTEDiPgW5py2tzlhRl/Um5yXoGbSOPELEdd7t6k6OCuRbJWt9YGckK+N8ra9twTq2u9ohtE761hmL8fyxF9nuMJZYA7H4Ir/zQfCEWp1UjTLsIw8xEZusMcYRgLIjhf9B7m0rK/mYjKKfJEzW6GEAYYoK/LLIYufRKaTh5rjPH9jUPuof6+bAP6nmt2JpII8R68sQNinCypwyCGXGRwSwy94zKdLMmjrxGuTpp1OBxXk8vTqlISJhDpi7mjoRerbIkCWZuc1jfjkrmC+tE/MJxm+6+bVcqaxzgC2fgvNZNtT+/0zD0uIzLypQkGipM9HW6SHDnQDsTitQHOE/dBI+KMau40pYfEDuqC6nNpPIl2axrtE4CY4voDkRdiK5OUavxBBjmQDNDY0AKQUgmIXjnaBUL4Fy73Pg5zQz1csyBJqJsXqBguaJygsrDTKPQQG5ttBGo/LNq6qrDod6mmot0dR2qVFssWHAuEJCTXDqdiLbJq6UemIlwe+g3BAtFY="
+cache:
+  directories:
+    - node_modules
 before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+  - npm install codeclimate-test-reporter istanbul -g
 script:
   - npm test
+  - istanbul cover npm test -- -R spec
   - npm run build
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - codeclimate-test-reporter < ./coverage/lcov.info
 # notifications:
 #     slack: andela:ODqDIMkl1Ds56Jxyrwc825vT

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 # travis configurations
-
+env:
+  global:
+    - CC_TEST_REPORTER_ID=ac09bc8945acb8a19e553ee46e5ddeab8058ac70cc6cd85cfb2dabb06331e11b
 language: node_js
 node_js:
   - "stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
   directories:
     - node_modules
 before_script:
-  - npm install codeclimate-test-reporter istanbul -g
+  - npm install codeclimate-test-reporter -g
 script:
   - npm test
-  - istanbul cover
+  - npm test -- --coverage
   - npm run build
 after_script:
   - codeclimate-test-reporter < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,18 @@ node_js:
 cache:
   directories:
     - node_modules
+addons:
+  code_climate:
+    repo_token:
+      secure: "m+NV4GPL9cEIHjnajmlvHqD9bLlWLng60i/t+Ih7CQrYvbWmf1/PHaDERayRJPP9i5vxc1NhI23IRwJybnrZGiH1oqiVx77JVBcVPl2WbNntVWsPWlsIj34uLWI+nDS85NBj3JHpLCT43Go3ECYkYSLU8sRNf+8IYVlc8g5zVKsZtTEDiPgW5py2tzlhRl/Um5yXoGbSOPELEdd7t6k6OCuRbJWt9YGckK+N8ra9twTq2u9ohtE761hmL8fyxF9nuMJZYA7H4Ir/zQfCEWp1UjTLsIw8xEZusMcYRgLIjhf9B7m0rK/mYjKKfJEzW6GEAYYoK/LLIYufRKaTh5rjPH9jUPuof6+bAP6nmt2JpII8R68sQNinCypwyCGXGRwSwy94zKdLMmjrxGuTpp1OBxXk8vTqlISJhDpi7mjoRerbIkCWZuc1jfjkrmC+tE/MJxm+6+bVcqaxzgC2fgvNZNtT+/0zD0uIzLypQkGipM9HW6SHDnQDsTitQHOE/dBI+KMau40pYfEDuqC6nNpPIl2axrtE4CY4voDkRdiK5OUavxBBjmQDNDY0AKQUgmIXjnaBUL4Fy73Pg5zQz1csyBJqJsXqBguaJygsrDTKPQQG5ttBGo/LNq6qrDod6mmot0dR2qVFssWHAuEJCTXDqdiLbJq6UemIlwe+g3BAtFY="
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - npm test
   - npm run build
-notifications:
-    slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+# notifications:
+#     slack: andela:ODqDIMkl1Ds56Jxyrwc825vT

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,6 @@
 language: node_js
 node_js:
   - "stable"
-addons:
-  code_climate:
-    repo_token:
-      secure: "m+NV4GPL9cEIHjnajmlvHqD9bLlWLng60i/t+Ih7CQrYvbWmf1/PHaDERayRJPP9i5vxc1NhI23IRwJybnrZGiH1oqiVx77JVBcVPl2WbNntVWsPWlsIj34uLWI+nDS85NBj3JHpLCT43Go3ECYkYSLU8sRNf+8IYVlc8g5zVKsZtTEDiPgW5py2tzlhRl/Um5yXoGbSOPELEdd7t6k6OCuRbJWt9YGckK+N8ra9twTq2u9ohtE761hmL8fyxF9nuMJZYA7H4Ir/zQfCEWp1UjTLsIw8xEZusMcYRgLIjhf9B7m0rK/mYjKKfJEzW6GEAYYoK/LLIYufRKaTh5rjPH9jUPuof6+bAP6nmt2JpII8R68sQNinCypwyCGXGRwSwy94zKdLMmjrxGuTpp1OBxXk8vTqlISJhDpi7mjoRerbIkCWZuc1jfjkrmC+tE/MJxm+6+bVcqaxzgC2fgvNZNtT+/0zD0uIzLypQkGipM9HW6SHDnQDsTitQHOE/dBI+KMau40pYfEDuqC6nNpPIl2axrtE4CY4voDkRdiK5OUavxBBjmQDNDY0AKQUgmIXjnaBUL4Fy73Pg5zQz1csyBJqJsXqBguaJygsrDTKPQQG5ttBGo/LNq6qrDod6mmot0dR2qVFssWHAuEJCTXDqdiLbJq6UemIlwe+g3BAtFY="
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ cache:
   directories:
     - node_modules
 before_script:
-  - npm install codeclimate-test-reporter istanbul -g
+  - npm install codeclimate-test-reporter -g
 script:
   - npm test
-  - istanbul cover node_modules/mocha/bin/_mocha -- -R spec
+  - npm test -- --coverage
   - npm run build
 after_script:
   - codeclimate-test-reporter < ./coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - npm install codeclimate-test-reporter istanbul -g
 script:
   - npm test
-  - istanbul cover npm test
+  - istanbul cover node_modules/mocha/bin/_mocha -- -R spec
   - npm run build
 after_script:
   - codeclimate-test-reporter < ./coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <!-- README file -->
 
 [![Build Status](https://travis-ci.org/andela/ah-scorpion-frontend.svg?branch=develop)](https://travis-ci.org/andela/ah-scorpion-frontend)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/34686a84f41c12b30532/test_coverage)](https://codeclimate.com/github/andela/ah-scorpion-frontend/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/34686a84f41c12b30532/maintainability)](https://codeclimate.com/github/andela/ah-scorpion-frontend/maintainability)
 
 # ah-scorpion-frontend
 


### PR DESCRIPTION
#### What does this PR do?
It adds Code Climate test coverage in the Travis yml file.

#### Description of Task to be completed?
1.  Implement `test-coverage` from `Code Climate`
2. Implement `code quality` from `Code Climate`

#### How should this be manually tested?
1. Clone the project by running `git clone https://github.com/andela/ah-scorpion-frontend.git` 
2. Switch to `ch-codeclimate-coverage-159993334` on the Terminal.
3. Make any changes and push to Github, it will trigger a Travis build and a test report on Code Climate.

#### What are the relevant pivotal tracker stories?
[#159993334](https://www.pivotaltracker.com/story/show/159993334)