### PR TITLE
#160206226 Deploy to Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,28 @@
-# travis configurations
 language: node_js
 node_js:
-  - "stable"
+- stable
 cache:
   directories:
-    - node_modules
+  - node_modules
 before_script:
-  - npm install codeclimate-test-reporter -g
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+- npm install codeclimate-test-reporter -g
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+  > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- "./cc-test-reporter before-build"
 script:
-  - npm install
-  - npm test
-  - npm test -- --coverage
-  - npm run build
+- npm install
+- npm test
+- npm test -- --coverage
 after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 notifications:
-    slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
+  slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
+deploy:
+  provider: heroku
+  api_key:
+    secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
+  strategy: git
+  app: authors-haven-frontend
+  on:
+    branch: deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ cache:
   - node_modules
 before_script:
 - npm install codeclimate-test-reporter -g
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 ./cc-test-reporter
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
+  > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_deploy:
   - npm run build
 deploy:
   provider: heroku
-  strategy: git
+  strategy: api
   api_key:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
   app:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ deploy:
   strategy: git
   api_key:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
-  app:
-    develop: authors-haven-frontend
-    authors-haven-dev
+  app: authors-haven-dev
   on:
     all_branches: true
+    develop: authors-haven-frontend

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_deploy:
   - npm run build
 deploy:
   provider: heroku
-  strategy: api
+  strategy: git
   api_key:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
   app:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ deploy:
   strategy: git
   app: authors-haven-frontend
   on:
-    branch: ch-deploy-to-heroku-160206226
+    branch: develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ deploy:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
   app:
     develop: authors-haven-frontend
-  on:
-    all_branches: true
+    demo: authors-haven-dev
+  skip_cleanup: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,15 @@ after_script:
 - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
 notifications:
   slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
+before_deploy:
+  - npm run build
 deploy:
   provider: heroku
   strategy: api
   api_key:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
-  app: authors-haven-frontend
+  app:
+    develop: authors-haven-frontend
   on:
-    branch: ch-deploy-to-heroku-160206226
+    all_branches: true
+    app: authors-haven-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ cache:
   - node_modules
 before_script:
 - npm install codeclimate-test-reporter -g
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-  > ./cc-test-reporter
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
 script:
@@ -23,4 +22,4 @@ deploy:
   strategy: git
   app: authors-haven-frontend
   on:
-    branch: deploy
+    branch: ch-deploy-to-heroku-160206226

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ notifications:
   slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
 deploy:
   provider: heroku
+  strategy: api
   api_key:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
-  strategy: git
   app: authors-haven-frontend
   on:
-    branch: develop
+    branch: ch-deploy-to-heroku-160206226

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,6 @@ deploy:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
   app:
     develop: authors-haven-frontend
+    authors-haven-dev
   on:
     all_branches: true
-    app: authors-haven-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ before_script:
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
 script:
-- npm install
-- npm test
 - npm test -- --coverage
 after_script:
 - "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ cache:
   - node_modules
 before_script:
 - npm install codeclimate-test-reporter -g
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
-  > ./cc-test-reporter
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
 - chmod +x ./cc-test-reporter
 - "./cc-test-reporter before-build"
 script:
@@ -23,7 +22,7 @@ deploy:
   strategy: git
   api_key:
     secure: gnliVC5BppBy/X0QF8sBkpz8hm4CbwDbPgp3xGY8zhWrg16gkzms2lsLjeg/FIEGFpuWa3AAHyqNC7qK5nCCaQnznkOsb9eegFrlVQZ4D9sOCtuygGHiQ6QbiIWV5oNsT2960AeARnzyTx5rU+rtb0l13MCod44LoTJ2xv8zOUqyGhuI9R+LNhy4S8C2KGv/SXdoJLZNMtfQH4WF5xWEqNAeQDadFtc/CGAqZ2noEynOkBheNEEUMCU/Ou/R2pWFDO/pFS7Q9hXsM5PRJ2PtCmg/HyM3svCXAJHnHzotzlBxzlmfiIHdpIZY8qzx3gRmzBd8AxtXDK43T8pxxs665oy/TqQ3RPW4Qm6vjV+CE5Pjdt6PoNOEgkszclIgKlHSVaejYdiC6baLOS+Z8g7HLQetK5+9RTTWJLOHd8KTAjV99aaoTaXgNYw45fHwo6Fa6OtFda5nI8T3jY8Dv1LTl9wUPmnE25Zk7q1m+JIFVjCmlpcAWJVEMebOJluGzQ6Gb1KG5xHdRbwzXazTriyODICK0lEM/L6T0tXiNMa+OlgnEsazP39ODDe5Gc+OUk9JoPEjRH+3bqCr2jvVyyMbUc7QTb5EqYKq+NqO3MKRb+H3f3t8IUafdc/Nd/KPb3z1TjtA5FkEXdUBEHjtYlAli9F8LTCEKg2BWg1P859XQAY=
-  app: authors-haven-dev
+  app:
+    develop: authors-haven-frontend
   on:
     all_branches: true
-    develop: authors-haven-frontend


### PR DESCRIPTION
#### What does this PR do?
- Deploys the Authors Haven frontend to Heroku.

#### Description of tasks completed
- Edited the [.travis.yml](https://github.com/andela/ah-scorpion-frontend/blob/ch-deploy-to-heroku-160206226/.travis.yml) to add `deploy`
  - `provider: heroku` The provider is [Heroku](https://heroku.com)
  - In the code below, one has to provide an encrypted authenticaion token provided by heroku.
     ```
     api_key:
       secure: [ENCRYPTED TOKEN HERE]
     ```
  - `strategy: api` Uses the [Heroku API](https://devcenter.heroku.com/articles/platform-api-reference) to deploy
  - The code below specifies the branch to be deployed
     ```
     app:
       develop: authors-haven-frontend
       demo: authors-haven-dev
     ```
     If the develop branch triggers the build then the app will be deployed to [authors-haven-frontend](https://authors-haven-frontend.herokuapp.com)
     If the demo branch triggers the build then the app will be deployed to [authors-haven-dev](https://authors-haven-dev.herokuapp.com)
  - `skip_cleanup: true` Travis will not stash changes and therefore will send the build directory
- Remove the `npm install`, `npm test` lines from the .travis.yml. This is because:
  - TravisCI runs `npm ci` which takes care of `npm install` for us.
  - The line `npm test -- --coverage` takes care of the tests with the coverage so `npm test` would be redundant

#### How can this PR be manually tested
- Visit https://authors-haven-frontend.herokuapp.com and it should show a page.
- Examine the Travis build [here](https://travis-ci.org/andela/ah-scorpion-frontend/builds/423152763#L3309) to view the deploy process after testing

#### What are the related PR stories
- [#160206226](https://www.pivotaltracker.com/story/show/160206226)