### PR TITLE
#160425794 Fix Travis build error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,22 @@
 language: node_js
 node_js:
-- stable
+  - stable
 cache:
   directories:
-  - node_modules
+    - node_modules
 before_script:
-- npm install codeclimate-test-reporter -g
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-- chmod +x ./cc-test-reporter
-- "./cc-test-reporter before-build"
+  - npm install codeclimate-test-reporter -g
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - './cc-test-reporter before-build'
 script:
-- npm test -- --coverage
+  - npm test -- --coverage
 after_script:
-- "./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT"
+  - './cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT'
 notifications:
   slack: andela:ODqDIMkl1Ds56Jxyrwc825vT
 before_deploy:
+  - unset CI
   - npm run build
 deploy:
   provider: heroku


### PR DESCRIPTION
#### What does this PR do?
Fixes the Travis build error in the `develop` branch
#### Description of Task to be completed?
`unset CI` in the Travis yml file which treats test warnings as errors.
#### How should this be manually tested?
This manually triggered [Travis build](https://travis-ci.org/andela/ah-scorpion-frontend/builds/427291218) shows that the `unset CI` command exits with a 0 and the `npm run build` command exits with a 0. The fail is due to invalid Heroku credentials. 
#### What are the relevant pivotal tracker stories?
[#60425794](https://www.pivotaltracker.com/story/show/160425794)